### PR TITLE
Add py2app build script for macOS app bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,25 @@ pip install git+https://github.com/TencentARC/GFPGAN.git@master
 
 **Run:** If you don't have a GPU, you can run Deep-Live-Cam using `python run.py`. Note that initial execution will download models (~300MB).
 
+### Building a macOS App Bundle
+
+If you prefer to distribute Deep Live Cam as a double-clickable macOS application, you can build a `.app` bundle using [`py2app`](https://py2app.readthedocs.io/).
+
+1. Make sure the required model files have already been downloaded into the `models` directory.
+2. Install `py2app` inside your virtual environment:
+
+   ```bash
+   pip install py2app
+   ```
+
+3. Run the build script from the project root:
+
+   ```bash
+   python3 setup_mac.py py2app
+   ```
+
+The generated application will be located at `dist/Deep Live Cam.app`. You can move this bundle into `/Applications` or share it with other macOS users. The app will include the `media`, `models`, and `locales` folders so it works offline after packaging.
+
 ### GPU Acceleration
 
 **CUDA Execution Provider (Nvidia)**

--- a/setup_mac.py
+++ b/setup_mac.py
@@ -1,0 +1,84 @@
+"""Build script for creating a standalone macOS application bundle.
+
+This repository primarily targets running Deep Live Cam via Python, but some
+contributors prefer shipping a double-clickable ``.app`` bundle for macOS
+users.  ``py2app`` is the most straightforward tool for packaging Tkinter
+applications on macOS, so this script wraps the existing ``run.py`` entry
+point and collects the resource folders required at runtime.
+
+Usage::
+
+    python3 setup_mac.py py2app
+
+The command will produce ``dist/Deep Live Cam.app``.  Make sure the ``models``
+directory already contains the required model weights before running the
+build.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+from setuptools import setup
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+APP: List[str] = ["run.py"]
+
+# Directories that should be copied verbatim into the application bundle so
+# the packaged app has access to media assets, localization files, and the
+# downloaded models.
+RESOURCE_FOLDERS = ["media", "models", "locales"]
+
+# Individual resource files that the application expects to load from disk.
+RESOURCE_FILES = ["mypi.ini", os.path.join("modules", "ui.json")]
+
+
+def _collect_data_files(paths: Iterable[str]) -> List[Tuple[str, List[str]]]:
+    """Return a list of data-file tuples compatible with ``setuptools``.
+
+    Each tuple contains the destination directory within the bundle and the
+    list of files that should be copied there.  ``py2app`` will merge these
+    into ``Resources`` inside the generated ``.app`` package.
+    """
+
+    data_files: List[Tuple[str, List[str]]] = []
+
+    for relative in paths:
+        absolute = ROOT / relative
+
+        if absolute.is_dir():
+            for path in absolute.rglob("*"):
+                if path.is_file():
+                    destination = os.path.relpath(path.parent, ROOT)
+                    data_files.append((destination, [str(path)]))
+        elif absolute.is_file():
+            destination = os.path.relpath(absolute.parent, ROOT)
+            data_files.append((destination, [str(absolute)]))
+
+    return data_files
+
+
+OPTIONS = {
+    "argv_emulation": True,
+    # The application relies on dynamic imports for some submodules, so we
+    # keep the zipfile uncompressed to simplify loading resources.
+    "compressed": False,
+    # ``py2app`` is usually able to discover the required packages
+    # automatically.  Explicitly include the project package to be safe.
+    "packages": ["modules"],
+}
+
+
+setup(
+    name="Deep Live Cam",
+    app=APP,
+    version="2.2",
+    options={"py2app": OPTIONS},
+    data_files=_collect_data_files(RESOURCE_FOLDERS + RESOURCE_FILES),
+    setup_requires=["py2app"],
+)


### PR DESCRIPTION
## Summary
- add a py2app-based setup script to package Deep Live Cam as a macOS application
- document the macOS app bundle build process in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e659df92a48323831eaa648164818b